### PR TITLE
Make MouseMoveArgs report actual delta mouse movement

### DIFF
--- a/src/OpenTK/Platform/Linux/LinuxNativeWindow.cs
+++ b/src/OpenTK/Platform/Linux/LinuxNativeWindow.cs
@@ -296,6 +296,9 @@ namespace OpenTK.Platform.Linux
                 int x = mouse.X;
                 int y = mouse.Y;
 
+                int xDelta = x - previous_mouse.X;
+                int yDelta = y - previous_mouse.Y;
+
                 // Make sure the mouse cannot leave the GameWindow when captured
                 if (!CursorVisible)
                 {
@@ -309,7 +312,7 @@ namespace OpenTK.Platform.Linux
 
                 if (x != previous_mouse.X || y != previous_mouse.Y)
                 {
-                    OnMouseMove(x, y);
+                    OnMouseMove(x, y, xDelta, yDelta);
                 }
             }
 

--- a/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
+++ b/src/OpenTK/Platform/MacOS/CocoaNativeWindow.cs
@@ -735,6 +735,9 @@ namespace OpenTK.Platform.MacOS
                             // Use absolute coordinates
                             var pf = Cocoa.SendPoint(e, selLocationInWindowOwner);
 
+                            var dx = (int)Math.Round(Cocoa.SendFloat(e, selDeltaX));
+                            var dy = (int)Math.Round(Cocoa.SendFloat(e, selDeltaY));
+
                             // Convert from points to pixel coordinates
                             var rf = Cocoa.SendRect(
                                 windowInfo.Handle,
@@ -761,11 +764,7 @@ namespace OpenTK.Platform.MacOS
                                 MoveCursorInWindow(p);
                             }
 
-                            // Only raise events when the mouse has actually moved
-                            if (MouseState.X != p.X || MouseState.Y != p.Y)
-                            {
-                                OnMouseMove(p.X, p.Y);
-                            }
+                            OnMouseMove(p.X, p.Y, dx, dy);
                         }
                         break;
 

--- a/src/OpenTK/Platform/NativeWindowBase.cs
+++ b/src/OpenTK/Platform/NativeWindowBase.cs
@@ -268,15 +268,15 @@ namespace OpenTK.Platform
             MouseUp(this, e);
         }
 
-        protected void OnMouseMove(int x, int y)
+        protected void OnMouseMove(int x, int y, int xDelta, int yDelta)
         {
             MouseState.X = x;
             MouseState.Y = y;
 
             var e = MouseMoveArgs;
             e.Mouse = MouseState;
-            e.XDelta = MouseState.X - PreviousMouseState.X;
-            e.YDelta = MouseState.Y - PreviousMouseState.Y;
+            e.XDelta = xDelta;
+            e.YDelta = yDelta;
 
             if (e.XDelta == 0 && e.YDelta == 0)
             {

--- a/src/OpenTK/Platform/SDL2/Sdl2NativeWindow.cs
+++ b/src/OpenTK/Platform/SDL2/Sdl2NativeWindow.cs
@@ -294,8 +294,8 @@ namespace OpenTK.Platform.SDL2
         {
             float scale = window.ClientSize.Width / (float)window.Size.Width;
             window.OnMouseMove(
-                (int)Math.Round(ev.X * scale),
-                (int)Math.Round(ev.Y * scale));
+                (int)Math.Round(ev.X * scale), (int)Math.Round(ev.Y * scale),
+                (int)Math.Round(ev.Xrel * scale), (int)Math.Round(ev.Yrel * scale));
             Sdl2Mouse.Scale = scale;
         }
 


### PR DESCRIPTION
.. instead of just the one computed from the previous position.

This should allow us to disable the use of `SetMousePositon` every time the mouse moves when it is captured, as long as it stays within window bounds. On SDL2, `SetMouseRelativeMode` should constrict the mouse to window bounds, but I'm not entirely sure if this will work on Mac if `CocoaNativeWindow` is used. So I strongly encourage testing with the changes made to the game.